### PR TITLE
Set raise parameter to false

### DIFF
--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -58,7 +58,7 @@ module QBWC
     def qwc
       qwc = <<QWC
 <QBWCXML>
-   <AppName>#{Rails.application.class.parent_name} #{Rails.env} #{@app_name_suffix}</AppName>
+   <AppName>#{Rails::VERSION::MAJOR >= 6 ? Rails.application.class.module_parent_name : Rails.application.class.parent_name} #{Rails.env} #{@app_name_suffix}</AppName>
    <AppID></AppID>
    <AppURL>#{QBWC.app_url || (root_url(:protocol => 'https://')+'qbwc/action')}</AppURL>
    <AppDescription>Quickbooks integration</AppDescription>
@@ -70,7 +70,7 @@ module QBWC
    <Style>Document</Style>
 </QBWCXML>
 QWC
-      send_data qwc, :filename => "#{@filename || Rails.application.class.parent_name}.qwc", :content_type => 'application/x-qwc'
+      send_data qwc, :filename => "#{@filename || Rails::VERSION::MAJOR >= 6 ? Rails.application.class.module_parent_name : Rails.application.class.parent_name}.qwc", :content_type => 'application/x-qwc'
     end
 
     class StringArray < WashOut::Type

--- a/lib/qbwc/controller.rb
+++ b/lib/qbwc/controller.rb
@@ -6,9 +6,9 @@ module QBWC
     def self.included(base)
       base.class_eval do
         include WashOut::SOAP
-        skip_before_filter :_parse_soap_parameters, :_authenticate_wsse, :_map_soap_parameters, :only => :qwc
-        before_filter :get_session, :except => [:qwc, :authenticate, :_generate_wsdl]
-        after_filter :save_session, :except => [:qwc, :authenticate, :_generate_wsdl, :close_connection, :connection_error]
+        skip_before_action :_parse_soap_parameters, :_authenticate_wsse, :_map_soap_parameters, raise: false, :only => :qwc
+        before_action :get_session, :except => [:qwc, :authenticate, :_generate_wsdl]
+        after_action :save_session, :except => [:qwc, :authenticate, :_generate_wsdl, :close_connection, :connection_error]
 
         # wash_out changed the format of app/views/wash_with_soap/rpc/response.builder in commit
         # https://github.com/inossidabile/wash_out/commit/24a77f4a3d874562732c6e8c3a30e8defafea7cb

--- a/lib/qbwc/qbwc_session.rb
+++ b/lib/qbwc/qbwc_session.rb
@@ -2,8 +2,8 @@ module QBWC
   class QbwcSession < ActiveRecord::Base
     before_create :setup
 
-    belongs_to :previous_job, class_name: QBWC::QbwcJob, foreign_key: :prev_qbwc_job_id
-    belongs_to :next_job,     class_name: QBWC::QbwcJob, foreign_key: :next_qbwc_job_id
+    belongs_to :previous_job, class_name: 'QBWC::QbwcJob', foreign_key: :prev_qbwc_job_id
+    belongs_to :next_job,     class_name: 'QBWC::QbwcJob', foreign_key: :next_qbwc_job_id
 
     attr_accessor :response
     @@before_session_hooks = Set.new

--- a/lib/qbwc/qbwc_session.rb
+++ b/lib/qbwc/qbwc_session.rb
@@ -2,8 +2,8 @@ module QBWC
   class QbwcSession < ActiveRecord::Base
     before_create :setup
 
-    belongs_to :previous_job, class_name: 'QBWC::QbwcJob', foreign_key: :prev_qbwc_job_id
-    belongs_to :next_job,     class_name: 'QBWC::QbwcJob', foreign_key: :next_qbwc_job_id
+    belongs_to :previous_job, class_name: 'QBWC::QbwcJob', foreign_key: :prev_qbwc_job_id, required: false
+    belongs_to :next_job,     class_name: 'QBWC::QbwcJob', foreign_key: :next_qbwc_job_id, required: false
 
     attr_accessor :response
     @@before_session_hooks = Set.new


### PR DESCRIPTION
Rails 5 raises an ArgumentError exception when the action is missing